### PR TITLE
feat: AudioPool 클래스 추가

### DIFF
--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78d30a06dc5511144b6263b20fc35324
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AudioServices.meta
+++ b/Assets/Scripts/AudioServices.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f5f6e65c5277c4a4fa8e475b703f0063
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AudioServices/AudioPool.cs
+++ b/Assets/Scripts/AudioServices/AudioPool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -11,25 +12,28 @@ public interface IAudioPool
     /// <summary>
     /// 모든 위치에서 동일한 음량으로 들을 수 있는 오디오를 재생합니다.
     /// </summary>
-    /// <param name="onEnd"><see cref="AudioSource.isPlaying">AudioSource.isPlaying</see>이 false로 변할 때 호출됩니다.</param>
+    /// <param name="autoRemove">재생중인 오디오가 끝나면 자동으로 소멸될 지 선택합니다.</param>
+    /// <param name="onEnd">재생중인 오디오가 끝나면 호출됩니다.</param>
     /// <returns>Pool로 반환하는 Dispose 함수를 구현하는 Disposable</returns>
-    IDisposable PlayGlobalAudio(AudioClip clip, Action onEnd = null);
+    IDisposable PlayGlobalAudio(AudioClip clip, bool autoRemove = true, Action onEnd = null);
 
 
     /// <summary>
     /// 위치에 따라 음량이 달라지는 오디오를 목표 위치에 생성하고 재생합니다.
     /// </summary>
-    /// <param name="onEnd"><see cref="AudioSource.isPlaying">AudioSource.isPlaying</see>이 false로 변할 때 호출됩니다.</param>
+    /// <param name="autoRemove">재생중인 오디오가 끝나면 자동으로 소멸될 지 선택합니다.</param>
+    /// <param name="onEnd">재생중인 오디오가 끝나면 호출됩니다.</param>
     /// <returns>Pool로 반환하는 Dispose 함수를 구현하는 Disposable</returns>
-    IDisposable PlayLocalAudio(AudioClip clip, Vector3 position, Action onEnd = null);
+    IDisposable PlayLocalAudio(AudioClip clip, Vector3 position, bool autoRemove = true, Action onEnd = null);
 
 
     /// <summary>
     /// 위치에 따라 음량이 달라지는 오디오를 목표 대상을 부모로 선택하고 재생합니다.
     /// </summary>
-    /// <param name="onEnd"><see cref="AudioSource.isPlaying">AudioSource.isPlaying</see>이 false로 변할 때 호출됩니다.</param>
+    /// <param name="autoRemove">재생중인 오디오가 끝나면 자동으로 소멸될 지 선택합니다.</param>
+    /// <param name="onEnd">재생중인 오디오가 끝나면 호출됩니다.</param>
     /// <returns>Pool로 반환하는 Dispose 함수를 구현하는 Disposable</returns>
-    IDisposable PlayLocalAudio(AudioClip clip, Transform parent, Action onEnd = null);
+    IDisposable PlayLocalAudio(AudioClip clip, Transform parent, bool autoRemove = true, Action onEnd = null);
 }
 
 
@@ -60,6 +64,7 @@ public class AudioPool : IAudioPool
             this.pool = pool;
         }
 
+
         public void Dispose()
         {
             pool.Release(this);
@@ -73,15 +78,18 @@ public class AudioPool : IAudioPool
 
     private readonly Settings settings;
     private readonly Transform globalAudioPoolRoot, localAudioPoolRoot;
+    private readonly ICoroutineRunner coroutineRunner;
 
     private readonly ObjectPool<AudioElement> globalAudioPool, localAudioPool;
 
     #endregion
 
 
-    public AudioPool(Settings settings)
+    public AudioPool(Settings settings, ICoroutineRunner coroutineRunner)
     {
         this.settings = settings;
+        this.coroutineRunner = coroutineRunner;
+
         this.globalAudioPoolRoot = new GameObject("GlobalAudioPool Root").transform;
 
         this.globalAudioPool = new ObjectPool<AudioElement>(createFunc: CreateGlobalAudioElement,
@@ -102,27 +110,30 @@ public class AudioPool : IAudioPool
     }
 
 
-    public IDisposable PlayGlobalAudio(AudioClip clip, Action onEnd = null)
+    public IDisposable PlayGlobalAudio(AudioClip clip, bool autoRemove = true, Action onEnd = null)
     {
-        var newElement = CreateGlobalAudioElement();
-        newElement.source.PlayOneShot(clip);
+        var newElement = globalAudioPool.Get();
+        newElement.source.clip = clip;
+        newElement.source.Play();
+
+        coroutineRunner.RequestStartCoroutine(AudioElementEndCheck(newElement, autoRemove, onEnd));
 
         return newElement;
     }
 
 
-    public IDisposable PlayLocalAudio(AudioClip clip, Vector3 position, Action onEnd = null)
+    public IDisposable PlayLocalAudio(AudioClip clip, Vector3 position, bool autoRemove = true, Action onEnd = null)
     {
-        var newElement = PlayLocalAudio(clip, onEnd);
+        var newElement = PlayLocalAudio(clip, autoRemove, onEnd);
         newElement.source.transform.position = position;
 
         return newElement;
     }
 
 
-    public IDisposable PlayLocalAudio(AudioClip clip, Transform parent, Action onEnd = null)
+    public IDisposable PlayLocalAudio(AudioClip clip, Transform parent, bool autoRemove = true, Action onEnd = null)
     {
-        var newElement = PlayLocalAudio(clip, onEnd);
+        var newElement = PlayLocalAudio(clip, autoRemove, onEnd);
         newElement.source.transform.SetParent(parent);
         newElement.source.transform.localPosition = Vector3.zero;
 
@@ -134,12 +145,29 @@ public class AudioPool : IAudioPool
     /// 위치에 따라 음량이 달라지는 오디오를 재생합니다.
     /// </summary>
     /// <param name="onEnd"><see cref="AudioSource.isPlaying">AudioSource.isPlaying</see>이 false로 변할 때 호출됩니다.</param>
-    private AudioElement PlayLocalAudio(AudioClip clip, Action onEnd = null)
+    private AudioElement PlayLocalAudio(AudioClip clip, bool autoRemove, Action onEnd)
     {
-        var newElement = CreateLocalAudioElement();
+        var newElement = localAudioPool.Get();
         newElement.source.PlayOneShot(clip);
 
+        coroutineRunner.RequestStartCoroutine(AudioElementEndCheck(newElement, autoRemove, onEnd));
+
         return newElement;
+    }
+
+
+    /// <summary>
+    /// 재생중인 오디오가 끝나면 element를 소멸시키고 onEnd 이벤트를 발생하는 코루틴을 생성합니다.
+    /// </summary>
+    private IEnumerator AudioElementEndCheck(AudioElement element, bool autoRemove, Action onEnd)
+    {
+        // AudioSource가 종료될 때까지 대기
+        yield return new WaitUntil(() => !element.source.isPlaying);
+
+        if (autoRemove)
+            element.Dispose();
+
+        onEnd?.Invoke();
     }
 
 
@@ -153,6 +181,8 @@ public class AudioPool : IAudioPool
 
     private void OnReturnedToPool(AudioElement element)
     {
+        element.source.Stop();
+        element.source.clip = null;
         element.source.gameObject.SetActive(false);
         element.source.transform.SetParent(globalAudioPoolRoot);
     }
@@ -164,6 +194,13 @@ public class AudioPool : IAudioPool
     }
 
 
+    /// <summary>
+    /// globalAudioPool이 새로운 Element를 생성하는 함수입니다.
+    /// <para>
+    /// 경고: ObjectPool에서 꺼내는 작업이 아닌 Pool을 초기화하는 데에 사용되는 함수입니다.
+    /// ObjectPool에서 사용 가능한 오브젝트를 꺼내려면 <see cref="ObjectPool{T}.Get">ObjectPool.Get()</see> 함수를 이용하세요.
+    /// </para>
+    /// </summary>
     private AudioElement CreateGlobalAudioElement()
     {
         GameObject newObject = new GameObject("GlobalAudioPool Element");
@@ -178,6 +215,13 @@ public class AudioPool : IAudioPool
     }
 
 
+    /// <summary>
+    /// localAudioPool이 새로운 Element를 생성하는 함수입니다.
+    /// <para>
+    /// 경고: ObjectPool에서 꺼내는 작업이 아닌 Pool을 초기화하는 데에 사용되는 함수입니다.
+    /// ObjectPool에서 사용 가능한 오브젝트를 꺼내려면 <see cref="ObjectPool{T}.Get">ObjectPool.Get()</see> 함수를 이용하세요.
+    /// </para>
+    /// </summary>
     private AudioElement CreateLocalAudioElement()
     {
         GameObject newObject = new GameObject("GlobalAudioPool Element");

--- a/Assets/Scripts/AudioServices/AudioPool.cs
+++ b/Assets/Scripts/AudioServices/AudioPool.cs
@@ -1,0 +1,196 @@
+using System;
+using UnityEngine;
+using UnityEngine.Pool;
+
+
+/// <summary>
+/// 오브젝트 풀을 사용해 <see cref="AudioSource">AudioSource</see>의 생성, 소멸을 제어합니다.
+/// </summary>
+public interface IAudioPool
+{
+    /// <summary>
+    /// 모든 위치에서 동일한 음량으로 들을 수 있는 오디오를 재생합니다.
+    /// </summary>
+    /// <param name="onEnd"><see cref="AudioSource.isPlaying">AudioSource.isPlaying</see>이 false로 변할 때 호출됩니다.</param>
+    /// <returns>Pool로 반환하는 Dispose 함수를 구현하는 Disposable</returns>
+    IDisposable PlayGlobalAudio(AudioClip clip, Action onEnd = null);
+
+
+    /// <summary>
+    /// 위치에 따라 음량이 달라지는 오디오를 목표 위치에 생성하고 재생합니다.
+    /// </summary>
+    /// <param name="onEnd"><see cref="AudioSource.isPlaying">AudioSource.isPlaying</see>이 false로 변할 때 호출됩니다.</param>
+    /// <returns>Pool로 반환하는 Dispose 함수를 구현하는 Disposable</returns>
+    IDisposable PlayLocalAudio(AudioClip clip, Vector3 position, Action onEnd = null);
+
+
+    /// <summary>
+    /// 위치에 따라 음량이 달라지는 오디오를 목표 대상을 부모로 선택하고 재생합니다.
+    /// </summary>
+    /// <param name="onEnd"><see cref="AudioSource.isPlaying">AudioSource.isPlaying</see>이 false로 변할 때 호출됩니다.</param>
+    /// <returns>Pool로 반환하는 Dispose 함수를 구현하는 Disposable</returns>
+    IDisposable PlayLocalAudio(AudioClip clip, Transform parent, Action onEnd = null);
+}
+
+
+/// <summary>
+/// 오브젝트 풀을 사용해 <see cref="AudioSource">AudioSource</see>의 생성, 소멸을 제어합니다.
+/// </summary>
+public class AudioPool : IAudioPool
+{
+    #region Nested Class, Struct
+
+    public struct Settings
+    {
+        public int globalAudioPoolDefaultSize, globalAudioPoolMaxSize;
+        public int localAudioPoolDefaultSize, localAudioPoolMaxSize;
+
+        public float globalAudioReverbZoneMix, localAudioReverbZoneMix;
+    }
+
+    private class AudioElement : IDisposable
+    {
+        public readonly AudioSource source;
+        private readonly IObjectPool<AudioElement> pool;
+
+
+        public AudioElement(AudioSource source, IObjectPool<AudioElement> pool)
+        {
+            this.source = source;
+            this.pool = pool;
+        }
+
+        public void Dispose()
+        {
+            pool.Release(this);
+        }
+    }
+
+    #endregion
+
+
+    #region Members
+
+    private readonly Settings settings;
+    private readonly Transform globalAudioPoolRoot, localAudioPoolRoot;
+
+    private readonly ObjectPool<AudioElement> globalAudioPool, localAudioPool;
+
+    #endregion
+
+
+    public AudioPool(Settings settings)
+    {
+        this.settings = settings;
+        this.globalAudioPoolRoot = new GameObject("GlobalAudioPool Root").transform;
+
+        this.globalAudioPool = new ObjectPool<AudioElement>(createFunc: CreateGlobalAudioElement,
+                                                       actionOnGet: OnTakeFromPool,
+                                                       actionOnRelease: OnReturnedToPool,
+                                                       actionOnDestroy: OnDestroyObject,
+                                                       collectionCheck: true,
+                                                       defaultCapacity: settings.globalAudioPoolDefaultSize,
+                                                       maxSize: settings.globalAudioPoolMaxSize);
+
+        this.localAudioPool = new ObjectPool<AudioElement>(createFunc: CreateLocalAudioElement,
+                                               actionOnGet: OnTakeFromPool,
+                                               actionOnRelease: OnReturnedToPool,
+                                               actionOnDestroy: OnDestroyObject,
+                                               collectionCheck: true,
+                                               defaultCapacity: settings.localAudioPoolDefaultSize,
+                                               maxSize: settings.localAudioPoolMaxSize);
+    }
+
+
+    public IDisposable PlayGlobalAudio(AudioClip clip, Action onEnd = null)
+    {
+        var newElement = CreateGlobalAudioElement();
+        newElement.source.PlayOneShot(clip);
+
+        return newElement;
+    }
+
+
+    public IDisposable PlayLocalAudio(AudioClip clip, Vector3 position, Action onEnd = null)
+    {
+        var newElement = PlayLocalAudio(clip, onEnd);
+        newElement.source.transform.position = position;
+
+        return newElement;
+    }
+
+
+    public IDisposable PlayLocalAudio(AudioClip clip, Transform parent, Action onEnd = null)
+    {
+        var newElement = PlayLocalAudio(clip, onEnd);
+        newElement.source.transform.SetParent(parent);
+        newElement.source.transform.localPosition = Vector3.zero;
+
+        return newElement;
+    }
+
+
+    /// <summary>
+    /// 위치에 따라 음량이 달라지는 오디오를 재생합니다.
+    /// </summary>
+    /// <param name="onEnd"><see cref="AudioSource.isPlaying">AudioSource.isPlaying</see>이 false로 변할 때 호출됩니다.</param>
+    private AudioElement PlayLocalAudio(AudioClip clip, Action onEnd = null)
+    {
+        var newElement = CreateLocalAudioElement();
+        newElement.source.PlayOneShot(clip);
+
+        return newElement;
+    }
+
+
+    #region Pool Manage Functions
+
+    private void OnDestroyObject(AudioElement element)
+    {
+        UnityEngine.Object.Destroy(element.source.gameObject);
+    }
+
+
+    private void OnReturnedToPool(AudioElement element)
+    {
+        element.source.gameObject.SetActive(false);
+        element.source.transform.SetParent(globalAudioPoolRoot);
+    }
+
+
+    private void OnTakeFromPool(AudioElement element)
+    {
+        element.source.gameObject.SetActive(true);
+    }
+
+
+    private AudioElement CreateGlobalAudioElement()
+    {
+        GameObject newObject = new GameObject("GlobalAudioPool Element");
+        AudioSource source = newObject.AddComponent<AudioSource>();
+        source.playOnAwake = false;
+        source.reverbZoneMix = settings.globalAudioReverbZoneMix;
+        newObject.transform.SetParent(globalAudioPoolRoot);
+
+        AudioElement newElement = new AudioElement(source, globalAudioPool);
+
+        return newElement;
+    }
+
+
+    private AudioElement CreateLocalAudioElement()
+    {
+        GameObject newObject = new GameObject("GlobalAudioPool Element");
+        AudioSource source = newObject.AddComponent<AudioSource>();
+        source.playOnAwake = false;
+        source.reverbZoneMix = settings.localAudioReverbZoneMix;
+        newObject.transform.SetParent(localAudioPoolRoot);
+
+        AudioElement newElement = new AudioElement(source, localAudioPool);
+
+        return newElement;
+    }
+
+    #endregion
+
+}

--- a/Assets/Scripts/AudioServices/AudioPool.cs.meta
+++ b/Assets/Scripts/AudioServices/AudioPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9cc138e57158e744a664e0a1b57e7e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AudioServices/CoroutineRunner.cs
+++ b/Assets/Scripts/AudioServices/CoroutineRunner.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using UnityEngine;
+
+
+
+/// <summary>
+/// MonoBehaviour를 상속받지 않아 코루틴을 직접 사용할 수 없는 객체 대신 코루틴을 실행해주는 서비스입니다.
+/// </summary>
+public interface ICoroutineRunner
+{
+    Coroutine RequestStartCoroutine(IEnumerator enumerator);
+}
+
+
+
+/// <summary>
+/// MonoBehaviour를 상속받지 않아 코루틴을 직접 사용할 수 없는 객체 대신 코루틴을 실행해주는 컴포넌트입니다.
+/// </summary>
+public class CoroutineRunner : MonoBehaviour, ICoroutineRunner
+{
+
+    public Coroutine RequestStartCoroutine(IEnumerator enumerator)
+    {
+        return RequestStartCoroutine(enumerator);
+    }
+}

--- a/Assets/Scripts/AudioServices/CoroutineRunner.cs.meta
+++ b/Assets/Scripts/AudioServices/CoroutineRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c0926b6ae693564696cf578f02e934d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Pull Request 유형
<!-- "x"를 사용하여 이 Pull Request에 해당하는 것을 체크해주세요. -->

- [ ] 버그 수정
- [X] 기능 추가
- [ ] 코드 스타일 업데이트
- [ ] 리팩토링 (기능 변경 없음, API 변경 없음)
- [ ] 문서 내용 변경
- [ ] 기타 사항: >>이 글을 지우고 새로 입력<<

## 요약

UnityEngine.Pool.ObjectPool<T>를 사용해 AudioSource 컴포넌트를 가진 게임 오브젝트의 생성/소멸을 제어하는 AudioPool 클래스를 추가함.

## 변경 사항 설명

1. SimulationGame/Scripts/AudioPool.cs 추가
- IAudioPool 인터페이스는 원하는 AudioClip을 재생하고 IDisposable을 반환하는 PlayGlobalAudio, PlayLocalAudio 함수를 구현합니다.
- 반환 받은 IDisposable의 Dispose 함수를 호출하면 재생 중인 AudioSource를 비활성화하고 속해 있던 ObjectPool로 되돌립니다.

2. SimulationGame/Scripts/CoroutineRunner.cs 추가
- ICoroutineRunner 인터페이스는 코루틴을 직접 사용할 수 없는 객체가 코루틴을 대신 호출하도록 요청받는 RequestStartCoroutine 함수를 구현합니다.