### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,2 @@
 [*]
-charset = utf-8-bom
+charset = utf-8


### PR DESCRIPTION
BOM이 Unix/Linux 환경에서 제대로 작동하지 않는 경우가 있어 UTF-8로 저장해야 함.

## Pull Request 유형
<!-- "x"를 사용하여 이 Pull Request에 해당하는 것을 체크해주세요. -->

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 업데이트
- [ ] 리팩토링 (기능 변경 없음, API 변경 없음)
- [ ] 문서 내용 변경
- [X] 기타 사항: 세팅 파일 수정

## 요약

텍스트 파일의 바이트 순서 표시를 나타내는 BOM(Byte Order Mark)는 Unix/Linux와 같은 비 Windows 운영체제에서 지원하지 않는 경우가 있음. 

## 변경 사항 설명

.editorconfig 파일의 파일 저장 방식을 UTF-8-BOM에서 UTF-8로 수정함.



